### PR TITLE
fix: map time entry names and adjust KB edit params

### DIFF
--- a/src/app/knowledge-base/edit/[slug]/page.tsx
+++ b/src/app/knowledge-base/edit/[slug]/page.tsx
@@ -16,7 +16,10 @@ import { Skeleton } from "@/components/ui/skeleton";
 import Link from "next/link";
 import { ChevronLeft } from "lucide-react";
 
-export default function EditArticlePage({ params }: { params: { slug: string } }) {
+// Next.js 15 passes `params` as a Promise in client components.
+// Unwrap it with React.use to access the actual values.
+export default function EditArticlePage({ params }: { params: Promise<{ slug: string }> }) {
+    const { slug } = React.use(params);
     const [article, setArticle] = React.useState<Article | null>(null);
     const [isLoading, setIsLoading] = React.useState(true);
     const router = useRouter();
@@ -26,7 +29,7 @@ export default function EditArticlePage({ params }: { params: { slug: string } }
         async function fetchArticle() {
             setIsLoading(true);
             try {
-                const fetchedArticle = await getArticleBySlug(params.slug);
+                const fetchedArticle = await getArticleBySlug(slug);
                 setArticle(fetchedArticle);
             } catch (error) {
                 toast({ title: "Error", description: "Could not fetch article.", variant: "destructive" });
@@ -36,7 +39,7 @@ export default function EditArticlePage({ params }: { params: { slug: string } }
             }
         }
         fetchArticle();
-    }, [params.slug, toast, router]);
+    }, [slug, toast, router]);
 
     const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();

--- a/src/services/timeTrackingService.ts
+++ b/src/services/timeTrackingService.ts
@@ -10,11 +10,16 @@ export async function getTimeEntries(): Promise<TimeEntry[]> {
     throw new Error('Could not fetch time entries.');
   }
   return (data ?? [])
-    .filter((entry: TimeEntry) => entry.date)
-    .sort(
-      (a: TimeEntry, b: TimeEntry) =>
-        new Date(b.date).getTime() - new Date(a.date).getTime()
-    );
+    .filter((entry: any) => entry.date)
+    .map((entry: any) => ({
+      id: entry.id,
+      date: entry.date,
+      teamMember: entry.name, // map DB field "name" to UI field "teamMember"
+      client: entry.client,
+      task: entry.task,
+      duration: entry.duration,
+    }))
+    .sort((a: TimeEntry, b: TimeEntry) => new Date(b.date).getTime() - new Date(a.date).getTime());
 }
 
 


### PR DESCRIPTION
## Summary
- map `name` column to `teamMember` when fetching time entries
- unwrap `params` promise on knowledge base edit page for Next 15

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6894a15106188328bb315a1a318981cb